### PR TITLE
Update to mtl-2.3.1 (remove ErrorT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 shell.nix
 .cabal-sandbox
 cabal.sandbox.config
+dist-newstyle

--- a/Text/ICalendar/Parser.hs
+++ b/Text/ICalendar/Parser.hs
@@ -12,7 +12,7 @@ module Text.ICalendar.Parser
 
 import           Control.Applicative
 import           Control.Monad
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Control.Monad.RWS          (runRWS)
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -70,4 +70,4 @@ parseICalFile = parseICalendarFile
 
 runCP :: DecodingFunctions -> ContentParser a
       -> (Either String a, (SourcePos, [Content]), [String])
-runCP s = ((flip .) . flip) runRWS s (undefined, undefined) . runErrorT
+runCP s = ((flip .) . flip) runRWS s (undefined, undefined) . runExceptT

--- a/Text/ICalendar/Parser/Common.hs
+++ b/Text/ICalendar/Parser/Common.hs
@@ -5,7 +5,7 @@ module Text.ICalendar.Parser.Common where
 
 import           Control.Applicative
 import           Control.Arrow                (second)
-import           Control.Monad.Error          hiding (mapM)
+import           Control.Monad.Except         (ExceptT, MonadError(throwError))
 import           Control.Monad.RWS            (MonadState (get, put),
                                                MonadWriter (tell), RWS, asks,
                                                modify)
@@ -42,6 +42,7 @@ import           Text.Parsec.Combinator hiding (optional)
 import           Text.Parsec.Prim       hiding ((<|>))
 
 import Text.ICalendar.Types
+import Control.Monad
 
 -- | Content lines, separated into components. 3.1.
 data Content = ContentLine P.SourcePos (CI Text) [(CI Text, [Text])] ByteString
@@ -50,7 +51,7 @@ data Content = ContentLine P.SourcePos (CI Text) [(CI Text, [Text])] ByteString
 
 type TextParser = P.Parsec ByteString DecodingFunctions
 
-type ContentParser = ErrorT String -- Fatal errors.
+type ContentParser = ExceptT String -- Fatal errors.
                             (RWS DecodingFunctions
                                  [String] -- Warnings.
                                  (P.SourcePos, [Content]))

--- a/Text/ICalendar/Parser/Components.hs
+++ b/Text/ICalendar/Parser/Components.hs
@@ -5,7 +5,7 @@ module Text.ICalendar.Parser.Components where
 
 import           Control.Applicative
 import           Control.Arrow        ((&&&))
-import           Control.Monad.Error  hiding (mapM)
+import           Control.Monad.Except
 import           Control.Monad.RWS    (MonadState (get), tell)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Foldable        as F
@@ -18,6 +18,7 @@ import qualified Data.Set             as S
 import Text.ICalendar.Parser.Common
 import Text.ICalendar.Parser.Properties
 import Text.ICalendar.Types
+import Control.Monad
 
 -- | Parse a VCALENDAR component. 3.4
 parseVCalendar :: Content -> ContentParser VCalendar

--- a/Text/ICalendar/Parser/Parameters.hs
+++ b/Text/ICalendar/Parser/Parameters.hs
@@ -2,7 +2,7 @@
 module Text.ICalendar.Parser.Parameters where
 
 import           Control.Applicative
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Control.Monad.RWS          (MonadWriter (tell))
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -22,6 +22,7 @@ import           Text.Parsec.Prim       hiding ((<|>))
 
 import Text.ICalendar.Parser.Common
 import Text.ICalendar.Types
+import Control.Monad
 
 parseAlarmTriggerRelationship :: CI Text
                               -> ContentParser AlarmTriggerRelationship

--- a/Text/ICalendar/Parser/Properties.hs
+++ b/Text/ICalendar/Parser/Properties.hs
@@ -5,7 +5,7 @@
 module Text.ICalendar.Parser.Properties where
 
 import           Control.Applicative
-import           Control.Monad.Error          hiding (mapM)
+import           Control.Monad.Except
 import           Control.Monad.RWS            (asks)
 import qualified Data.ByteString.Base64.Lazy  as B64
 import qualified Data.ByteString.Lazy.Char8   as B
@@ -27,6 +27,7 @@ import Text.Parsec.Prim hiding ((<|>))
 import Text.ICalendar.Parser.Common
 import Text.ICalendar.Parser.Parameters
 import Text.ICalendar.Types
+import Control.Monad
 
 parseFreeBusy :: Content -> ContentParser FreeBusy
 parseFreeBusy (ContentLine _ "FREEBUSY" o bs) = do

--- a/iCalendar.cabal
+++ b/iCalendar.cabal
@@ -48,5 +48,5 @@ library
                      , case-insensitive >=0.4
                      , bytestring >=0.11 && <1.0.0, parsec >=3.1.0
                      , text, containers >= 0.5 && < 0.7, mime >=0.4.0.2
-                     , mtl >=2.1.0, old-locale, base64-bytestring >=1.0.0
+                     , mtl >=2.3.1, old-locale, base64-bytestring >=1.0.0
   ghc-options:       -Wall


### PR DESCRIPTION
Hey, with the removal of ErrorT in 2.3.0 this no longer built, so I made the changes necessary to use ExceptT. (I built this with 9.6.3). Also, has there been any info regarding a package takeover?
